### PR TITLE
Update users.conf to add user to 'power' and 'rfkill' group

### DIFF
--- a/etc/calamares/modules/users.conf
+++ b/etc/calamares/modules/users.conf
@@ -40,6 +40,14 @@ defaultGroups:
       must_exist: false
       system: true
     - audio
+    - name: rfkill
+      must_exist: false
+      system: true
+    # Adding user to 'rfkill' allows unpriveleged user to 
+    # turn bluetooth on/off with bluetooth frontends.
+    - power
+    # On some systems, suspend (sleep) does not work well 
+    # if the unpriveleged user initiating suspend is not in 'power' group.
 
 # Some Distributions require a 'autologin' group for the user.
 # Autologin causes a user to become automatically logged in to


### PR DESCRIPTION
The advantage of adding user to 'power' and 'rfkill' is mentioned in comment in users.conf, so that for future reference, it remains there why adding to these groups is required